### PR TITLE
Fix typo in Source Code section: "soure" → "source"

### DIFF
--- a/lib/pages/home_page.ex
+++ b/lib/pages/home_page.ex
@@ -24,7 +24,7 @@ defmodule ExpertLspOrg.HomePage do
       end
 
       p class: "font-sans mt-8 text-lg mb-8" do
-        "The soure code is available on"
+        "The source code is available on"
         a class: "text-purple-500 hover:underline", href: "https://github.com/elixir-lang/expert" do
           "GitHub."
         end


### PR DESCRIPTION
This pull request makes a small correction to the homepage text, fixing a typo in the message about the source code.

* Corrected the spelling of "soure" to "source" in the homepage message in `lib/pages/home_page.ex`.