### PR TITLE
fix: update footer repository link

### DIFF
--- a/lib/expert_lsp_org/layouts/root_layout.ex
+++ b/lib/expert_lsp_org/layouts/root_layout.ex
@@ -90,7 +90,7 @@ defmodule ExpertLspOrg.RootLayout do
 
           ", and"
 
-          a href: "https://github.com/elixir-tools/expert-lsp.org",
+          a href: "https://github.com/expert-lsp/expert-lsp.org",
             target: "_blank",
             rel: "noreferrer",
             class: "text-hacker italic text-red-500" do


### PR DESCRIPTION
This was still pointing to `elixir-tools/expert-lsp.org`.