### PR TITLE
update example flake

### DIFF
--- a/_pages/docs/installation.md
+++ b/_pages/docs/installation.md
@@ -61,7 +61,10 @@ We provide a flake that can be used.
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    expert.url = "github:expert-lsp/expert";
+    expert = {
+      url = "github:expert-lsp/expert";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
@@ -86,7 +89,7 @@ We provide a flake that can be used.
     }: {
       default = pkgs.mkShell {
         packages = with pkgs; [
-          elixir_1_18
+          elixir_1_19
           erlang
           expert.packages.${system}.default
         ];

--- a/_pages/docs/installation.md
+++ b/_pages/docs/installation.md
@@ -67,35 +67,44 @@ We provide a flake that can be used.
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    expert,
-  }: let
-    systems = [
-      "x86_64-linux"
-      "aarch64-darwin"
-    ];
-    forAllSystems = f:
-      nixpkgs.lib.genAttrs systems (system:
-        f {
-          inherit system;
-          pkgs = nixpkgs.legacyPackages.${system};
-        });
-  in {
-    devShells = forAllSystems ({
-      system,
-      pkgs,
-    }: {
-      default = pkgs.mkShell {
-        packages = with pkgs; [
-          elixir_1_19
-          erlang
-          expert.packages.${system}.default
-        ];
-      };
-    });
-  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      expert,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            inherit system;
+            pkgs = nixpkgs.legacyPackages.${system};
+          }
+        );
+    in
+    {
+      devShells = forAllSystems (
+        {
+          system,
+          pkgs,
+        }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              elixir_1_19
+              erlang
+              expert.packages.${system}.default
+            ];
+          };
+        }
+      );
+    };
 }
 ```
 


### PR DESCRIPTION
Updates the example flake to follow the same `nixpkgs` version as the root flake. I don't know whether you consider this a good recommendation. If not, feel free to close this PR.

Also bumps the Elixir version in the example and formats the flake with `nixfmt`.