### PR TITLE
docs: update `mise`/source install instructions

### DIFF
--- a/_pages/docs/installation.md
+++ b/_pages/docs/installation.md
@@ -27,24 +27,8 @@ brew install expert
 
 ### Mason
 
-```
+```vim
 :MasonInstall expert
-```
-
-### Mise
-
-[Mise](https://mise.jdx.dev/) can install Expert using the Aqua backend for `expert-lsp/expert`, supporting all released versions, including on Windows.
-
-#### Install
-
-```sh
-mise use aqua:expert-lsp/expert
-```
-
-#### List versions
-
-```sh
-mise ls-remote aqua:expert-lsp/expert
 ```
 
 ### Nix
@@ -118,6 +102,24 @@ or
 paru -s expert-git
 ```
 
+## Version Managers
+
+### Mise
+
+[Mise](https://mise.en.dev/) can install Expert, supporting all released versions, including on Windows.
+
+#### Install
+
+```sh
+mise use expert
+```
+
+#### List versions
+
+```sh
+mise ls-remote expert
+```
+
 ## GitHub Releases
 
 > [!caution]
@@ -126,22 +128,22 @@ paru -s expert-git
 
 You can easily install Expert with the [gh](https://github.com/cli/cli) CLI and save it somewhere on your machine.
 
-```shell
+```sh
 # Linux AMD64
-$ gh release download nightly \
+gh release download nightly \
   --pattern *linux_amd64 \
   --output ~/.local/bin/expert \
   --clobber \
   --repo expert-lsp/expert
 
 # Apple Silicon
-$ gh release download nightly \
+gh release download nightly \
   --pattern *darwin_arm64 \
   --output ~/.local/bin/expert \
   --clobber \
   --repo expert-lsp/expert
 
-$ chmod +x ~/.local/bin/expert
+chmod +x ~/.local/bin/expert
 ```
 
 You can also manually download the executable from the [releases](https://github.com/expert-lsp/expert/releases) page.
@@ -157,16 +159,11 @@ You can also manually download the executable from the [releases](https://github
 > Expert uses [just](https://just.systems/man/en/). You can install it with your systems package manager.
 
 Recipes for building from source are located in our [justfile](https://github.com/expert-lsp/expert/blob/main/justfile).
+The following builds a release for your OS, copies it to `~/.local/libexec/expert`, and symlinks
+the executable to `~/.local/bin/expert`.
 
-```shell
-# Builds an executable for your OS and copies it into `~/.local/bin/`
-$ just install
+```sh
+just install
 ```
 
-You can also skip cross-platform builds by running:
-
-```shell
-$ just release
-```
-
-And following the instructions in the output to point your editor to this build.
+You can install it somewhere other than `~/.local` with the `--prefix` flag.


### PR DESCRIPTION
The `mise` install is now much simpler - in addition, tools like `mise`, `asdf`, and so on are usually classified as version managers

As for the source install, the instructions here should now mirror those found at `expert-lsp/expert`