### PR TITLE
fix: fetch changelog from latest tag

### DIFF
--- a/_data/changelog.exs
+++ b/_data/changelog.exs
@@ -1,4 +1,4 @@
-if File.exists?("_build/changelog.md") and Mix.env() == :prod do
+if File.exists?("_build/changelog.md") do
   File.read!("_build/changelog.md")
 else
   github_api = "https://api.github.com/repos/expert-lsp/expert/tags"

--- a/_data/changelog.exs
+++ b/_data/changelog.exs
@@ -1,8 +1,16 @@
-if File.exists?("_build/changelog.md") do
+if File.exists?("_build/changelog.md") and Mix.env() == :prod do
   File.read!("_build/changelog.md")
 else
+  github_api = "https://api.github.com/repos/expert-lsp/expert/tags"
+  base_url = "https://raw.githubusercontent.com/expert-lsp/expert/refs"
+
   %{body: page} =
-    Req.get!("https://raw.githubusercontent.com/expert-lsp/expert/refs/heads/main/CHANGELOG.md")
+    with %{body: [object | _]} <- Req.get!(github_api),
+         %{"name" => tag} when not is_nil(tag) <- object do
+      Req.get!("#{base_url}/tags/#{tag}/CHANGELOG.md")
+    else
+      _ -> Req.get!("#{base_url}/heads/main/CHANGELOG.md")
+    end
 
   File.write!("_build/changelog.md", page)
 


### PR DESCRIPTION
Use the GitHub API to find the latest tag and fetch the changelog from there

Fallback to fetching from main if we can't resolve the latest tag for any reason

Fixes #26